### PR TITLE
remove redundant api in name

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -1,4 +1,4 @@
-service: autostat-api
+service: autostat
 
 provider:
   name: aws


### PR DESCRIPTION
The -api postfix resulted in a lambda name of autostat-api-dev-api.